### PR TITLE
Remove unused node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/fragsalat/lib-sass-data-uri#readme",
   "dependencies": {
-    "mime-types": "^2.1.11",
-    "node-sass": "^3.8.0"
+    "mime-types": "^2.1.11"
   }
 }


### PR DESCRIPTION
Due to npm's dependency model this only gives lib-sass-data-uri its own
private copy of node-sass. For example, I am using lib-sass-data-uri
with node-sass 4, and this dependency merely adds an unused copy of
node-sass 3.