### PR TITLE
Attempt (dart)sass, then node-sass, then throw error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,20 @@
-var sass = require('node-sass');
+var sass;
 var fs = require('fs');
 var path = require('path');
 var mime = require('mime-types');
 var jspm;
+
+try {
+    sass = require('sass');
+}
+catch(e) { }
+
+if (!sass) {
+    try {
+        sass = require('node-sass');
+    }
+    catch(e) { throw new Error('Cannot find either sass or node-sass'); }
+}
 
 try {
     jspm = require('jspm');


### PR DESCRIPTION
This patch offers an alternative fix for issue #6.

In it, we attempt to require sass first, then node-sass, before bailing.